### PR TITLE
Add all missing mastodon api entities

### DIFF
--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Attachment.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Attachment.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * https://docs.joinmastodon.org/entities/emoji/
+ * https://docs.joinmastodon.org/entities/attachment/
  */
 @Serializable
 data class Attachment(
     // required attributes
     val id: String,
-    val type: String,
+    val type: AttachmentType,
     val url: String,
     @SerialName("preview_url") val previewUrl: String,
 
@@ -26,7 +26,11 @@ data class Attachment(
 )
 
 enum class AttachmentType {
-    UNKNOWN, IMAGE, GIFV, VIDEO, AUDIO
+    unknown,
+    image,
+    gifv,
+    video,
+    audio,
 }
 
 @Serializable

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Card.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Card.kt
@@ -1,0 +1,36 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/card/
+ */
+@Serializable
+data class Card(
+    // base attributes
+    @SerialName("url") val url: String,
+    @SerialName("title") val title: String,
+    @SerialName("description") val description: String,
+    @SerialName("type") val type: CardType,
+
+    // optional attributes
+    @SerialName("author_name") val authorName: String? = null,
+    @SerialName("author_url") val authorUrl: String? = null,
+    @SerialName("provider_name") val providerName: String? = null,
+    @SerialName("provider_url") val providerUrl: String? = null,
+    @SerialName("html") val html: String? = null,
+    @SerialName("width") val width: Int? = null,
+    @SerialName("height") val height: Int? = null,
+    @SerialName("image") val image: String? = null,
+    @SerialName("embed_url") val embedUrl: String? = null,
+    @SerialName("blurhash") val blurhash: String? = null,
+)
+
+@Serializable
+enum class CardType {
+    link,
+    photo,
+    video,
+    rich,
+}

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Context.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Context.kt
@@ -1,0 +1,14 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/context/
+ */
+@Serializable
+data class Context(
+    // required attributes
+    @SerialName("ancestors") val ancestors: List<Status>,
+    @SerialName("descendants") val descendants: List<Status>,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Conversation.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Conversation.kt
@@ -1,0 +1,18 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/conversation/
+ */
+@Serializable
+data class Conversation(
+    // required attributes
+    @SerialName("id") val id: String,
+    @SerialName("accounts") val accounts: List<Account>,
+    @SerialName("unread") val unread: Boolean,
+
+    // optional attributes
+    @SerialName("last_status") val lastStatus: Status,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Error.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Error.kt
@@ -4,14 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * https://docs.joinmastodon.org/entities/tag/
+ * https://docs.joinmastodon.org/entities/error/
  */
 @Serializable
-data class Tag(
+data class Error(
     // required attributes
-    @SerialName("name") val name: String,
-    @SerialName("url") val url: String,
+    @SerialName("error") val error: String,
 
     // optional attributes
-    @SerialName("history") val history: List<History>,
+    @SerialName("error_description") val errorDescription: String? = null,
 )

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/FeaturedTag.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/FeaturedTag.kt
@@ -1,0 +1,20 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/featuredtag/
+ */
+@Serializable
+data class FeaturedTag(
+    // required attributes
+    @SerialName("id") val id: String,
+    @SerialName("name") val name: String,
+    @SerialName("url") val url: String,
+    @SerialName("statuses_count") val statusesCount: Int,
+    @SerialName("last_status_at") val lastStatusAt: String,
+
+    // optional attributes
+    @SerialName("history") val history: List<History>? = null,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Filter.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Filter.kt
@@ -1,0 +1,22 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/filter/
+ */
+@Serializable
+data class Filter(
+    @SerialName("id") val id: String,
+    @SerialName("phrase") val phrase: String,
+    @SerialName("context") val context: List<FilterContext>,
+    @SerialName("expires_at") val expiresAt: String,
+    @SerialName("irreversible") val irreversible: Boolean,
+    @SerialName("whole_word") val wholeWord: Boolean,
+
+)
+
+enum class FilterContext {
+    home, notifications, public, thread
+}

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/IdentityProof.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/IdentityProof.kt
@@ -1,0 +1,17 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+     * https://docs.joinmastodon.org/entities/identityproof/
+ */
+@Serializable
+data class IdentityProof(
+    // required attributes
+    @SerialName("provider") val provider: String,
+    @SerialName("provider_username") val providerUsername: String,
+    @SerialName("profile_url") val profileUrl: String,
+    @SerialName("proof_url") val proofUrl: String,
+    @SerialName("updated_at") val updatedAt: String,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Marker.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Marker.kt
@@ -1,0 +1,21 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/marker/
+ */
+@Serializable
+data class Marker(
+    // required attributes
+    @SerialName("home") val home: MarkerHash,
+    @SerialName("notifications") val uses: MarkerHash,
+)
+
+@Serializable
+data class MarkerHash(
+    @SerialName("last_read_id") val lastReadId: String,
+    @SerialName("updated_at") val updatedAt: String,
+    @SerialName("version") val version: Int,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Notification.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Notification.kt
@@ -1,0 +1,23 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/notification/
+ */
+@Serializable
+data class Notification(
+    // required attributes
+    @SerialName("id") val id: String,
+    @SerialName("type") val type: NotificationType,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("account") val account: Account,
+
+    // optional attributes
+    @SerialName("status") val status: Status,
+)
+
+enum class NotificationType {
+    follow, follow_request, mention, reblog, favourite, poll, status
+}

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Poll.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Poll.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * https://docs.joinmastodon.org/entities/emoji/
+ * https://docs.joinmastodon.org/entities/poll/
  */
 @Serializable
 data class Poll(

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Preferences.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Preferences.kt
@@ -1,0 +1,28 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/preferences/
+ */
+@Serializable
+data class Preferences(
+    // required attributes
+    @SerialName("posting:default:visibility") val postingVisibility: PostingVisibility,
+    @SerialName("posting:default:sensitive") val postingSensitive: Boolean,
+    @SerialName("posting:default:language") val postingLanguage: String? = null,
+    @SerialName("reading:expand:media") val readingMedia: ReadingMedia,
+    @SerialName("reading:expand:spoilers") val readingSpoilers: Boolean,
+
+    // optional attributes
+    @SerialName("history") val history: List<History>? = null,
+)
+
+enum class PostingVisibility {
+    public, unlisted, private, direct
+}
+
+enum class ReadingMedia {
+    default, show_all, hide_all
+}

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/PushSubscription.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/PushSubscription.kt
@@ -1,0 +1,25 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/pushsubscription/
+ */
+@Serializable
+data class PushSubscription(
+    // required attributes
+    @SerialName("id") val id: String,
+    @SerialName("endpoint") val endpoint: String,
+    @SerialName("server_key") val serverKey: String,
+    @SerialName("alerts") val alerts: Alerts,
+)
+
+@Serializable
+data class Alerts(
+    val follow: Boolean,
+    val favourite: Boolean,
+    val mention: Boolean,
+    val reblog: Boolean,
+    val poll: Boolean,
+)

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Source.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Source.kt
@@ -20,4 +20,4 @@ data class Source(
     @SerialName("follow_requests_count") val followRequestsCount: Int,
 )
 
-enum class Privacy { PUBLIC, UNLISTED, PRIVATE, DIRECT }
+enum class Privacy { public, unlisted, private, direct }

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Status.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/Status.kt
@@ -36,7 +36,7 @@ data class Status(
     @SerialName("in_reply_to_account_id") val inReplyToAccountId: String? = null,
     @SerialName("reblog") val reblog: Status? = null,
     @SerialName("poll") val poll: Poll? = null,
-//    @SerialName("card") val card: Card? = null,
+    @SerialName("card") val card: Card? = null,
     @SerialName("language") val language: String? = null,
     @SerialName("text") val text: String? = null,
 

--- a/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/UserList.kt
+++ b/data/network/src/commonMain/kotlin/social/androiddev/common/network/model/UserList.kt
@@ -1,0 +1,17 @@
+package social.androiddev.common.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * https://docs.joinmastodon.org/entities/list/
+ */
+@Serializable
+data class UserList(
+    // required attributes
+    @SerialName("id") val id: String,
+    @SerialName("title") val title: String,
+    @SerialName("replies_policy") val repliesPolicy: RepliesPolicy,
+)
+
+enum class RepliesPolicy { followed, list, none }

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/MastodonApiTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/MastodonApiTests.kt
@@ -25,13 +25,10 @@ class MastodonApiTests {
     @Test
     fun `Instance request should fail with invalid response`() = runBlocking {
         // given
+        val content: String = javaClass.classLoader.getResource("response_instance_invalid.json").readText()
         val mastodonApi = MastodonApiImpl(
             httpClient = createMockClient(
-                statusCode = HttpStatusCode.Unauthorized, content = ByteReadChannel(
-                    """
-                    {"error":"Access denied. Please check your credentials."}
-                """.trimIndent()
-                )
+                statusCode = HttpStatusCode.Unauthorized, content = ByteReadChannel(text = content)
             )
         )
 
@@ -46,75 +43,11 @@ class MastodonApiTests {
     @Test
     fun `Instance request should succeed with required field response`() = runBlocking {
         // given
+        val content: String = javaClass.classLoader.getResource("response_instance_valid.json").readText()
+
         val mastodonApi = MastodonApiImpl(
             httpClient = createMockClient(
-                statusCode = HttpStatusCode.Unauthorized, content = ByteReadChannel(
-                    """
-                    {
-                        "uri": "mastodon.social",
-                        "title": "Mastodon",
-                        "description": "Server run by the main developers of the project <img draggable=\"false\" alt=\"🐘\" class=\"emojione\" src=\"https://mastodon.social/emoji/1f418.svg\" /> It is not focused on any particular niche interest - everyone is welcome as long as you follow our code of conduct!",
-                        "short_description": "Server run by the main developers of the project <img draggable=\"false\" alt=\"🐘\" class=\"emojione\" src=\"https://mastodon.social/emoji/1f418.svg\" /> It is not focused on any particular niche interest - everyone is welcome as long as you follow our code of conduct!",
-                        "email": "staff@mastodon.social",
-                        "version": "3.0.1",
-                        "languages":
-                        [
-                            "en"
-                        ],
-                        "registrations": true,
-                        "approval_required": false,
-                        "invites_enabled": true,
-                        "urls":
-                        {
-                            "streaming_api": "wss://mastodon.social"
-                        },
-                        "stats":
-                        {
-                            "user_count": 415526,
-                            "status_count": 17085754,
-                            "domain_count": 11834
-                        },
-                        "user_count": 415526,
-                        
-                        "thumbnail": "https://files.mastodon.social/site_uploads/files/000/000/001/original/vlcsnap-2018-08-27-16h43m11s127.png",
-                        "contact_account":
-                        {
-                            "id": "1",
-                            "username": "Gargron",
-                            "acct": "Gargron",
-                            "display_name": "Eugen",
-                            "locked": false,
-                            "bot": false,
-                            "created_at": "2016-03-16T14:34:26.392Z",
-                            "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
-                            "url": "https://mastodon.social/@Gargron",
-                            "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
-                            "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
-                            "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
-                            "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
-                            "followers_count": 317112,
-                            "following_count": 453,
-                            "statuses_count": 60903,
-                            "last_status_at": "2019-11-26T21:14:44.522Z",
-                            "emojis": [],
-                            "discoverable": false,
-                            "fields":
-                            [
-                                {
-                                    "name": "Patreon",
-                                    "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
-                                    "verified_at": null
-                                },
-                                {
-                                    "name": "Homepage",
-                                    "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
-                                    "verified_at": "2019-07-15T18:29:57.191+00:00"
-                                }
-                            ]
-                        }
-                    }
-                """.trimIndent()
-                )
+                statusCode = HttpStatusCode.Unauthorized, content = ByteReadChannel(text = content)
             )
         )
 

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AttachmentTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AttachmentTests.kt
@@ -51,7 +51,7 @@ class AttachmentTests {
         // then
         Truth.assertThat(attachment).isNotNull()
         Truth.assertThat(attachment.id).isEqualTo("22345792")
-        Truth.assertThat(attachment.type).isEqualTo("image")
+        Truth.assertThat(attachment.type).isEqualTo(AttachmentType.image)
     }
 
     @Test
@@ -104,7 +104,7 @@ class AttachmentTests {
         // then
         Truth.assertThat(attachment).isNotNull()
         Truth.assertThat(attachment.id).isEqualTo("22546306")
-        Truth.assertThat(attachment.type).isEqualTo("video")
+        Truth.assertThat(attachment.type).isEqualTo(AttachmentType.video)
     }
 
     @Test
@@ -154,7 +154,7 @@ class AttachmentTests {
         // then
         Truth.assertThat(attachment).isNotNull()
         Truth.assertThat(attachment.id).isEqualTo("21130559")
-        Truth.assertThat(attachment.type).isEqualTo("gifv")
+        Truth.assertThat(attachment.type).isEqualTo(AttachmentType.gifv)
     }
 
     @Test
@@ -192,6 +192,6 @@ class AttachmentTests {
         // then
         Truth.assertThat(attachment).isNotNull()
         Truth.assertThat(attachment.id).isEqualTo("21165404")
-        Truth.assertThat(attachment.type).isEqualTo("audio")
+        Truth.assertThat(attachment.type).isEqualTo(AttachmentType.audio)
     }
 }

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/CardTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/CardTests.kt
@@ -1,0 +1,135 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class CardTests {
+    @Test
+    fun `deserialize video card should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "url": "https://www.youtube.com/watch?v=OMv_EPMED8Y",
+            "title": "♪ Brand New Friend (Christmas Song!)",
+            "description": "",
+            "type": "video",
+            "author_name": "YOGSCAST Lewis & Simon",
+            "author_url": "https://www.youtube.com/user/BlueXephos",
+            "provider_name": "YouTube",
+            "provider_url": "https://www.youtube.com/",
+            "html": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/OMv_EPMED8Y?feature=oembed\" frameborder=\"0\" allowfullscreen=\"\"></iframe>",
+            "width": 480,
+            "height": 270,
+            "image": "https://files.mastodon.social/preview_cards/images/014/179/145/original/9cf4b7cf5567b569.jpeg",
+            "embed_url": "",
+            "blurhash": "UvK0HNkV,:s9xBR%njog0fo2W=WBS5ozofV@"
+        }
+        """.trimIndent()
+
+        // when
+        val card = Json.decodeFromString<Card>(json)
+
+        // then
+        Truth.assertThat(card.url).isEqualTo("https://www.youtube.com/watch?v=OMv_EPMED8Y")
+        Truth.assertThat(card.title).isEqualTo("♪ Brand New Friend (Christmas Song!)")
+        Truth.assertThat(card.description).isEqualTo("")
+        Truth.assertThat(card.type).isEqualTo(CardType.video)
+        Truth.assertThat(card.authorName).isEqualTo("YOGSCAST Lewis & Simon")
+        Truth.assertThat(card.authorUrl).isEqualTo("https://www.youtube.com/user/BlueXephos")
+        Truth.assertThat(card.providerName).isEqualTo("YouTube")
+        Truth.assertThat(card.providerUrl).isEqualTo("https://www.youtube.com/")
+        Truth.assertThat(card.html).isEqualTo("<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/OMv_EPMED8Y?feature=oembed\" frameborder=\"0\" allowfullscreen=\"\"></iframe>")
+        Truth.assertThat(card.width).isEqualTo(480)
+        Truth.assertThat(card.height).isEqualTo(270)
+        Truth.assertThat(card.image).isEqualTo("https://files.mastodon.social/preview_cards/images/014/179/145/original/9cf4b7cf5567b569.jpeg")
+        Truth.assertThat(card.embedUrl).isEqualTo("")
+        Truth.assertThat(card.blurhash).isEqualTo("UvK0HNkV,:s9xBR%njog0fo2W=WBS5ozofV@")
+    }
+
+    @Test
+    fun `deserialize photo card should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "url": "https://www.flickr.com/photos/tomfenskephotography/49088768431/",
+            "title": "Oregon",
+            "description": "",
+            "type": "photo",
+            "author_name": "Tom Fenske Photography",
+            "author_url": "https://www.flickr.com/photos/tomfenskephotography/",
+            "provider_name": "Flickr",
+            "provider_url": "https://www.flickr.com/",
+            "html": "",
+            "width": 1024,
+            "height": 427,
+            "image": "https://files.mastodon.social/preview_cards/images/014/287/139/original/651b1c6976817824.jpeg",
+            "embed_url": "https://live.staticflickr.com/65535/49088768431_6a4322b3bb_b.jpg",
+            "blurhash": "UnE{@jt6M_oIAhjYs+ayT2WBf9ayRkkDXAj["
+        }
+        """.trimIndent()
+
+        // when
+        val card = Json.decodeFromString<Card>(json)
+
+        // then
+        Truth.assertThat(card.url).isEqualTo("https://www.flickr.com/photos/tomfenskephotography/49088768431/")
+        Truth.assertThat(card.title).isEqualTo("Oregon")
+        Truth.assertThat(card.description).isEqualTo("")
+        Truth.assertThat(card.type).isEqualTo(CardType.photo)
+        Truth.assertThat(card.authorName).isEqualTo("Tom Fenske Photography")
+        Truth.assertThat(card.authorUrl).isEqualTo("https://www.flickr.com/photos/tomfenskephotography/")
+        Truth.assertThat(card.providerName).isEqualTo("Flickr")
+        Truth.assertThat(card.providerUrl).isEqualTo("https://www.flickr.com/")
+        Truth.assertThat(card.html).isEqualTo("")
+        Truth.assertThat(card.width).isEqualTo(1024)
+        Truth.assertThat(card.height).isEqualTo(427)
+        Truth.assertThat(card.image).isEqualTo("https://files.mastodon.social/preview_cards/images/014/287/139/original/651b1c6976817824.jpeg")
+        Truth.assertThat(card.embedUrl).isEqualTo("https://live.staticflickr.com/65535/49088768431_6a4322b3bb_b.jpg")
+        Truth.assertThat(card.blurhash).isEqualTo("UnE{@jt6M_oIAhjYs+ayT2WBf9ayRkkDXAj[")
+    }
+
+    @Test
+    fun `deserialize link card should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+            "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+            "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+            "type": "link",
+            "author_name": "",
+            "author_url": "",
+            "provider_name": "",
+            "provider_url": "",
+            "html": "",
+            "width": 0,
+            "height": 0,
+            "image": null,
+            "embed_url": "",
+            "blurhash": null
+        }
+        """.trimIndent()
+
+        // when
+        val card = Json.decodeFromString<Card>(json)
+
+        // then
+        Truth.assertThat(card.url).isEqualTo("https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code")
+        Truth.assertThat(card.title).isEqualTo("‘I lost my £193,000 inheritance – with one wrong digit on my sort code’")
+        Truth.assertThat(card.description).isEqualTo("When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture")
+        Truth.assertThat(card.type).isEqualTo(CardType.link)
+        Truth.assertThat(card.authorName).isEqualTo("")
+        Truth.assertThat(card.authorUrl).isEqualTo("")
+        Truth.assertThat(card.providerName).isEqualTo("")
+        Truth.assertThat(card.providerUrl).isEqualTo("")
+        Truth.assertThat(card.html).isEqualTo("")
+        Truth.assertThat(card.width).isEqualTo(0)
+        Truth.assertThat(card.height).isEqualTo(0)
+        Truth.assertThat(card.image).isEqualTo(null)
+        Truth.assertThat(card.embedUrl).isEqualTo("")
+        Truth.assertThat(card.blurhash).isEqualTo(null)
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ContextTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ContextTests.kt
@@ -1,0 +1,32 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import java.io.InputStream
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class ContextTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json: String = javaClass.classLoader.getResource("response_context_required.json").readText()
+
+        // when
+        val context = Json.decodeFromString<Context>(json)
+
+        // then
+        Truth.assertThat(context).isNotNull()
+        Truth.assertThat(context.ancestors).isNotNull()
+        Truth.assertThat(context.ancestors.size).isEqualTo(1)
+        Truth.assertThat(context.descendants).isNotNull()
+        Truth.assertThat(context.descendants.size).isEqualTo(1)
+
+        val firstAncestor = context.ancestors[0]
+        Truth.assertThat(firstAncestor.id).isEqualTo("103270115826048975")
+
+        val firstDescendants = context.descendants[0]
+        Truth.assertThat(firstDescendants.id).isEqualTo("103270115826048975")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ConversationTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ConversationTests.kt
@@ -1,0 +1,27 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class ConversationTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json: String = javaClass.classLoader.getResource("response_conversation_required.json").readText()
+
+        // when
+        val conversation = Json.decodeFromString<Conversation>(json)
+
+        // then
+        Truth.assertThat(conversation).isNotNull()
+        Truth.assertThat(conversation.id).isEqualTo("418450")
+        Truth.assertThat(conversation.accounts).isNotNull()
+        Truth.assertThat(conversation.accounts.size).isEqualTo(1)
+        Truth.assertThat(conversation.unread).isEqualTo(true)
+        Truth.assertThat(conversation.lastStatus).isNotNull()
+        Truth.assertThat(conversation.lastStatus.id).isEqualTo("103270115826048975")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ErrorTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ErrorTests.kt
@@ -1,0 +1,27 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class ErrorTests {
+    @Test
+    fun `deserialize video card should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "error": "invalid_grant",
+            "error_description": "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+        }
+        """.trimIndent()
+
+        // when
+        val error = Json.decodeFromString<Error>(json)
+
+        // then
+        Truth.assertThat(error.error).isEqualTo("invalid_grant")
+        Truth.assertThat(error.errorDescription).isEqualTo("The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FeatureTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FeatureTests.kt
@@ -1,0 +1,32 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class FeatureTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "id": "627",
+            "name": "nowplaying",
+            "url": "",
+            "statuses_count": 36,
+            "last_status_at": "2019-11-15T07:14:43.524Z"
+        }
+        """.trimIndent()
+
+        // when
+        val featuredTag = Json.decodeFromString<FeaturedTag>(json)
+
+        // then
+        Truth.assertThat(featuredTag.id).isEqualTo("627")
+        Truth.assertThat(featuredTag.name).isEqualTo("nowplaying")
+        Truth.assertThat(featuredTag.statusesCount).isEqualTo(36)
+        Truth.assertThat(featuredTag.lastStatusAt).isEqualTo("2019-11-15T07:14:43.524Z")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FilterTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FilterTests.kt
@@ -1,0 +1,48 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class FilterTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "id": "8449",
+            "phrase": "test",
+            "context":
+            [
+                "home",
+                "notifications",
+                "public",
+                "thread"
+            ],
+            "whole_word": false,
+            "expires_at": "2019-11-26T09:08:06.254Z",
+            "irreversible": true
+        }
+        """.trimIndent()
+
+        // when
+        val filter = Json.decodeFromString<Filter>(json)
+
+        // then
+        Truth.assertThat(filter.id).isEqualTo("8449")
+        Truth.assertThat(filter.phrase).isEqualTo("test")
+        Truth.assertThat(filter.context).isEqualTo(
+            listOf(
+                FilterContext.home,
+                FilterContext.notifications,
+                FilterContext.public,
+                FilterContext.thread
+            )
+        )
+        Truth.assertThat(filter.wholeWord).isEqualTo(false)
+        Truth.assertThat(filter.expiresAt).isEqualTo("2019-11-26T09:08:06.254Z")
+        Truth.assertThat(filter.irreversible).isEqualTo(true)
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/IdentityProofTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/IdentityProofTests.kt
@@ -1,0 +1,33 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class IdentityProofTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "provider": "Keybase",
+            "provider_username": "gargron",
+            "updated_at": "2019-07-21T20:14:39.596Z",
+            "proof_url": "https://keybase.io/gargron/sigchain#5cfc20c7018f2beefb42a68836da59a792e55daa4d118498c9b1898de7e845690f",
+            "profile_url": "https://keybase.io/gargron"
+        }
+        """.trimIndent()
+
+        // when
+        val identityProof = Json.decodeFromString<IdentityProof>(json)
+
+        // then
+        Truth.assertThat(identityProof.provider).isEqualTo("Keybase")
+        Truth.assertThat(identityProof.providerUsername).isEqualTo("gargron")
+        Truth.assertThat(identityProof.updatedAt).isEqualTo("2019-07-21T20:14:39.596Z")
+        Truth.assertThat(identityProof.proofUrl).isEqualTo("https://keybase.io/gargron/sigchain#5cfc20c7018f2beefb42a68836da59a792e55daa4d118498c9b1898de7e845690f")
+        Truth.assertThat(identityProof.profileUrl).isEqualTo("https://keybase.io/gargron")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MarkerTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MarkerTests.kt
@@ -1,0 +1,47 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class MarkerTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "home":
+            {
+                "last_read_id": "103194548672408537",
+                "version": 462,
+                "updated_at": "2019-11-24T19:39:39.337Z"
+            },
+            "notifications":
+            {
+                "last_read_id": "35050107",
+                "version": 356,
+                "updated_at": "2019-11-25T13:47:31.333Z"
+            }
+        }
+        """.trimIndent()
+
+        // when
+        val marker = Json.decodeFromString<Marker>(json)
+
+        // then
+        val homeHash = MarkerHash(
+            lastReadId = "103194548672408537",
+            version = 462,
+            updatedAt = "2019-11-24T19:39:39.337Z"
+        )
+        val usesHash = MarkerHash(
+            lastReadId = "35050107",
+            version = 356,
+            updatedAt = "2019-11-25T13:47:31.333Z"
+        )
+        Truth.assertThat(marker.home).isEqualTo(homeHash)
+        Truth.assertThat(marker.uses).isEqualTo(usesHash)
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/NotificationTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/NotificationTests.kt
@@ -1,0 +1,28 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class NotificationTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json: String = javaClass.classLoader.getResource("response_notification_required.json").readText()
+
+        // when
+        val notification = Json.decodeFromString<Notification>(json)
+
+        // then
+        Truth.assertThat(notification).isNotNull()
+        Truth.assertThat(notification.id).isEqualTo("34975861")
+        Truth.assertThat(notification.type).isEqualTo(NotificationType.mention)
+        Truth.assertThat(notification.createdAt).isEqualTo("2019-11-23T07:49:02.064Z")
+        Truth.assertThat(notification.account).isNotNull()
+        Truth.assertThat(notification.account.id).isEqualTo("23634")
+        Truth.assertThat(notification.status).isNotNull()
+        Truth.assertThat(notification.status.id).isEqualTo("103270115826048975")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PreferencesTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PreferencesTests.kt
@@ -1,0 +1,33 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class PreferencesTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "posting:default:visibility": "public",
+            "posting:default:sensitive": false,
+            "posting:default:language": null,
+            "reading:expand:media": "default",
+            "reading:expand:spoilers": false
+        }
+        """.trimIndent()
+
+        // when
+        val preferences = Json.decodeFromString<Preferences>(json)
+
+        // then
+        Truth.assertThat(preferences.postingVisibility).isEqualTo(PostingVisibility.public)
+        Truth.assertThat(preferences.postingSensitive).isEqualTo(false)
+        Truth.assertThat(preferences.postingLanguage).isNull()
+        Truth.assertThat(preferences.readingMedia).isEqualTo(ReadingMedia.default)
+        Truth.assertThat(preferences.readingSpoilers).isEqualTo(false)
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PushSubscriptionTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PushSubscriptionTests.kt
@@ -1,0 +1,42 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class PushSubscriptionTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "id": "328183",
+            "endpoint": "https://yourdomain.example/listener",
+            "alerts":
+            {
+                "follow": false,
+                "favourite": false,
+                "reblog": false,
+                "mention": true,
+                "poll": false
+            },
+            "server_key": "BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M="
+        }
+        """.trimIndent()
+
+        // when
+        val subscription = Json.decodeFromString<PushSubscription>(json)
+
+        // then
+        Truth.assertThat(subscription.id).isEqualTo("328183")
+        Truth.assertThat(subscription.endpoint).isEqualTo("https://yourdomain.example/listener")
+        Truth.assertThat(subscription.alerts.follow).isEqualTo(false)
+        Truth.assertThat(subscription.alerts.favourite).isEqualTo(false)
+        Truth.assertThat(subscription.alerts.reblog).isEqualTo(false)
+        Truth.assertThat(subscription.alerts.mention).isEqualTo(true)
+        Truth.assertThat(subscription.alerts.poll).isEqualTo(false)
+        Truth.assertThat(subscription.serverKey).isEqualTo("BCk-QqERU0q-CfYZjcuB6lnyyOYfJ2AifKqfeGIm7Z-HiTU5T9eTG5GxVA0_OH5mMlI4UkkDTpaZwozy0TzdZ2M=")
+    }
+}

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/StatusTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/StatusTests.kt
@@ -6,16 +6,17 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.junit.Test
 
-class AccountTests {
+class StatusTests {
     @Test
     fun `deserialize required fields should succeed`() = runBlocking {
         // given
-        val json: String = javaClass.classLoader.getResource("response_account_required.json").readText()
+        val json: String = javaClass.classLoader.getResource("response_status_required.json").readText()
 
         // when
-        val account = Json.decodeFromString<Account>(json)
+        val status = Json.decodeFromString<Status>(json)
 
         // then
-        Truth.assertThat(account.id).isEqualTo("23634")
+        Truth.assertThat(status).isNotNull()
+        Truth.assertThat(status.id).isEqualTo("103270115826048975")
     }
 }

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/UserListTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/UserListTests.kt
@@ -1,0 +1,29 @@
+package social.androiddev.common.network.model
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class UserListTests {
+    @Test
+    fun `deserialize required fields should succeed`() = runBlocking {
+        // given
+        val json = """
+        {
+            "id": "12249",
+            "title": "Friends",
+            "replies_policy": "list"
+        }
+        """.trimIndent()
+
+        // when
+        val userList = Json.decodeFromString<UserList>(json)
+
+        // then
+        Truth.assertThat(userList.id).isEqualTo("12249")
+        Truth.assertThat(userList.title).isEqualTo("Friends")
+        Truth.assertThat(userList.repliesPolicy).isEqualTo(RepliesPolicy.list)
+    }
+}

--- a/data/network/src/commonTest/resources/response_account_required.json
+++ b/data/network/src/commonTest/resources/response_account_required.json
@@ -1,0 +1,64 @@
+{
+  "id": "23634",
+  "username": "noiob",
+  "acct": "noiob@awoo.space",
+  "display_name": "ikea shark fan account",
+  "locked": false,
+  "bot": false,
+  "created_at": "2017-02-08T02:00:53.274Z",
+  "note": "<p>:ms_rainbow_flag:​ :ms_bisexual_flagweb:​ :ms_nonbinary_flag:​ <a href=\"https://awoo.space/tags/awoo\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>awoo</span}.space <a href=\"https://awoo.space/tags/admin\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>admin</span} ~ <a href=\"https://awoo.space/tags/bi\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>bi</span} ~ <a href=\"https://awoo.space/tags/nonbinary\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>nonbinary</span} ~ compsci student ~ likes video <a href=\"https://awoo.space/tags/games\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>games</span} and weird/ old electronics and will post obsessively about both ~ avatar by <span class=\"h-card\"><a href=\"https://weirder.earth/@dzuk\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>dzuk</span}</span></p>",
+  "url": "https://awoo.space/@noiob",
+  "avatar": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+  "avatar_static": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+  "header": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+  "header_static": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+  "followers_count": 547,
+  "following_count": 404,
+  "discoverable": false,
+  "statuses_count": 28468,
+  "last_status_at": "2019-11-17T00:02:23.693Z",
+  "emojis":
+  [
+    {
+      "shortcode": "ms_rainbow_flag",
+      "url": "https://files.mastodon.social/custom_emojis/images/000/028/691/original/6de008d6281f4f59.png",
+      "static_url": "https://files.mastodon.social/custom_emojis/images/000/028/691/static/6de008d6281f4f59.png",
+      "visible_in_picker": true
+    },
+    {
+      "shortcode": "ms_bisexual_flag",
+      "url": "https://files.mastodon.social/custom_emojis/images/000/050/744/original/02f94a5fca7eaf78.png",
+      "static_url": "https://files.mastodon.social/custom_emojis/images/000/050/744/static/02f94a5fca7eaf78.png",
+      "visible_in_picker": true
+    },
+    {
+      "shortcode": "ms_nonbinary_flag",
+      "url": "https://files.mastodon.social/custom_emojis/images/000/105/099/original/8106088bd4782072.png",
+      "static_url": "https://files.mastodon.social/custom_emojis/images/000/105/099/static/8106088bd4782072.png",
+      "visible_in_picker": true
+    }
+  ],
+  "fields":
+  [
+    {
+      "name": "Pronouns",
+      "value": "they/them",
+      "verified_at": null
+    },
+    {
+      "name": "Alt",
+      "value": "<span class=\"h-card\"><a href=\"https://cybre.space/@noiob\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>noiob</span}</span>",
+      "verified_at": null
+    },
+    {
+      "name": "Bots",
+      "value": "<span class=\"h-card\"><a href=\"https://botsin.space/@darksouls\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>darksouls</span}</span>, <span class=\"h-card\"><a href=\"https://botsin.space/@nierautomata\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>nierautomata</span}</span>, <span class=\"h-card\"><a href=\"https://mastodon.social/@fedi\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>fedi</span}</span>, code for <span class=\"h-card\"><a href=\"https://botsin.space/@awoobot\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>awoobot</span}</span>",
+      "verified_at": null
+    },
+    {
+      "name": "Website",
+      "value": "<a href=\"http://shork.xyz\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">http://</span><span class=\"\">shork.xyz</span><span class=\"invisible\"></span}",
+      "verified_at": "2019-11-10T10:31:10.744+00:00"
+    }
+  ]
+}

--- a/data/network/src/commonTest/resources/response_context_required.json
+++ b/data/network/src/commonTest/resources/response_context_required.json
@@ -1,0 +1,182 @@
+{
+    "ancestors":
+    [
+        {
+            "id": "103270115826048975",
+            "created_at": "2019-12-08T03:48:33.901Z",
+            "in_reply_to_id": null,
+            "in_reply_to_account_id": null,
+            "sensitive": false,
+            "spoiler_text": "",
+            "visibility": "public",
+            "language": "en",
+            "uri": "https://mastodon.social/users/Gargron/statuses/103270115826048975",
+            "url": "https://mastodon.social/@Gargron/103270115826048975",
+            "replies_count": 5,
+            "reblogs_count": 6,
+            "favourites_count": 11,
+            "favourited": false,
+            "reblogged": false,
+            "muted": false,
+            "bookmarked": false,
+            "content": "<p>&quot;I lost my inheritance with one wrong digit on my sort code&quot;</p><p><a href=\"https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">theguardian.com/money/2019/dec</span><span class=\"invisible\">/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code</span}</p>",
+            "reblog": null,
+            "application":
+            {
+                "name": "Web",
+                "website": null
+            },
+            "account":
+            {
+                "id": "1",
+                "username": "Gargron",
+                "acct": "Gargron",
+                "display_name": "Eugen",
+                "locked": false,
+                "bot": false,
+                "discoverable": true,
+                "created_at": "2016-03-16T14:34:26.392Z",
+                "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
+                "url": "https://mastodon.social/@Gargron",
+                "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+                "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+                "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+                "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+                "followers_count": 322930,
+                "following_count": 459,
+                "statuses_count": 61323,
+                "last_status_at": "2019-12-10T08:14:44.811Z",
+                "emojis":
+                [],
+                "fields":
+                [
+                    {
+                        "name": "Patreon",
+                        "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
+                        "verified_at": null
+                    },
+                    {
+                        "name": "Homepage",
+                        "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
+                        "verified_at": "2019-07-15T18:29:57.191+00:00"
+                    }
+                ]
+            },
+            "media_attachments":
+            [],
+            "mentions":
+            [],
+            "tags":
+            [],
+            "emojis":
+            [],
+            "card":
+            {
+                "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+                "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+                "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+                "type": "link",
+                "author_name": "",
+                "author_url": "",
+                "provider_name": "",
+                "provider_url": "",
+                "html": "",
+                "width": 0,
+                "height": 0,
+                "image": null,
+                "embed_url": ""
+            },
+            "poll": null
+        }
+    ],
+    "descendants":
+    [
+        {
+            "id": "103270115826048975",
+            "created_at": "2019-12-08T03:48:33.901Z",
+            "in_reply_to_id": null,
+            "in_reply_to_account_id": null,
+            "sensitive": false,
+            "spoiler_text": "",
+            "visibility": "public",
+            "language": "en",
+            "uri": "https://mastodon.social/users/Gargron/statuses/103270115826048975",
+            "url": "https://mastodon.social/@Gargron/103270115826048975",
+            "replies_count": 5,
+            "reblogs_count": 6,
+            "favourites_count": 11,
+            "favourited": false,
+            "reblogged": false,
+            "muted": false,
+            "bookmarked": false,
+            "content": "<p>&quot;I lost my inheritance with one wrong digit on my sort code&quot;</p><p><a href=\"https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">theguardian.com/money/2019/dec</span><span class=\"invisible\">/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code</span}</p>",
+            "reblog": null,
+            "application":
+            {
+                "name": "Web",
+                "website": null
+            },
+            "account":
+            {
+                "id": "1",
+                "username": "Gargron",
+                "acct": "Gargron",
+                "display_name": "Eugen",
+                "locked": false,
+                "bot": false,
+                "discoverable": true,
+                "created_at": "2016-03-16T14:34:26.392Z",
+                "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
+                "url": "https://mastodon.social/@Gargron",
+                "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+                "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+                "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+                "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+                "followers_count": 322930,
+                "following_count": 459,
+                "statuses_count": 61323,
+                "last_status_at": "2019-12-10T08:14:44.811Z",
+                "emojis":
+                [],
+                "fields":
+                [
+                    {
+                        "name": "Patreon",
+                        "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
+                        "verified_at": null
+                    },
+                    {
+                        "name": "Homepage",
+                        "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
+                        "verified_at": "2019-07-15T18:29:57.191+00:00"
+                    }
+                ]
+            },
+            "media_attachments":
+            [],
+            "mentions":
+            [],
+            "tags":
+            [],
+            "emojis":
+            [],
+            "card":
+            {
+                "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+                "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+                "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+                "type": "link",
+                "author_name": "",
+                "author_url": "",
+                "provider_name": "",
+                "provider_url": "",
+                "html": "",
+                "width": 0,
+                "height": 0,
+                "image": null,
+                "embed_url": ""
+            },
+            "poll": null
+        }
+    ]
+}

--- a/data/network/src/commonTest/resources/response_conversation_required.json
+++ b/data/network/src/commonTest/resources/response_conversation_required.json
@@ -1,0 +1,188 @@
+{
+    "id": "418450",
+    "unread": true,
+    "accounts":
+    [
+        {
+            "id": "23634",
+            "username": "noiob",
+            "acct": "noiob@awoo.space",
+            "display_name": "ikea shark fan account",
+            "locked": false,
+            "bot": false,
+            "created_at": "2017-02-08T02:00:53.274Z",
+            "note": "<p>:ms_rainbow_flag:​ :ms_bisexual_flagweb:​ :ms_nonbinary_flag:​ <a href=\"https://awoo.space/tags/awoo\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>awoo</span}.space <a href=\"https://awoo.space/tags/admin\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>admin</span} ~ <a href=\"https://awoo.space/tags/bi\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>bi</span} ~ <a href=\"https://awoo.space/tags/nonbinary\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>nonbinary</span} ~ compsci student ~ likes video <a href=\"https://awoo.space/tags/games\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>games</span} and weird/ old electronics and will post obsessively about both ~ avatar by <span class=\"h-card\"><a href=\"https://weirder.earth/@dzuk\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>dzuk</span}</span></p>",
+            "url": "https://awoo.space/@noiob",
+            "avatar": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+            "avatar_static": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+            "header": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+            "header_static": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+            "followers_count": 547,
+            "following_count": 404,
+            "discoverable": false,
+            "statuses_count": 28468,
+            "last_status_at": "2019-11-17T00:02:23.693Z",
+            "emojis":
+            [
+                {
+                    "shortcode": "ms_rainbow_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/028/691/original/6de008d6281f4f59.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/028/691/static/6de008d6281f4f59.png",
+                    "visible_in_picker": true
+                },
+                {
+                    "shortcode": "ms_bisexual_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/050/744/original/02f94a5fca7eaf78.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/050/744/static/02f94a5fca7eaf78.png",
+                    "visible_in_picker": true
+                },
+                {
+                    "shortcode": "ms_nonbinary_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/105/099/original/8106088bd4782072.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/105/099/static/8106088bd4782072.png",
+                    "visible_in_picker": true
+                }
+            ],
+            "fields":
+            [
+                {
+                    "name": "Pronouns",
+                    "value": "they/them",
+                    "verified_at": null
+                },
+                {
+                    "name": "Alt",
+                    "value": "<span class=\"h-card\"><a href=\"https://cybre.space/@noiob\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>noiob</span}</span>",
+                    "verified_at": null
+                },
+                {
+                    "name": "Bots",
+                    "value": "<span class=\"h-card\"><a href=\"https://botsin.space/@darksouls\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>darksouls</span}</span>, <span class=\"h-card\"><a href=\"https://botsin.space/@nierautomata\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>nierautomata</span}</span>, <span class=\"h-card\"><a href=\"https://mastodon.social/@fedi\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>fedi</span}</span>, code for <span class=\"h-card\"><a href=\"https://botsin.space/@awoobot\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>awoobot</span}</span>",
+                    "verified_at": null
+                },
+                {
+                    "name": "Website",
+                    "value": "<a href=\"http://shork.xyz\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">http://</span><span class=\"\">shork.xyz</span><span class=\"invisible\"></span}",
+                    "verified_at": "2019-11-10T10:31:10.744+00:00"
+                }
+            ]
+        }
+    ],
+    "last_status":
+    {
+        "id": "103270115826048975",
+        "created_at": "2019-12-08T03:48:33.901Z",
+        "in_reply_to_id": null,
+        "in_reply_to_account_id": null,
+        "sensitive": false,
+        "spoiler_text": "",
+        "visibility": "public",
+        "language": "en",
+        "uri": "https://mastodon.social/users/Gargron/statuses/103270115826048975",
+        "url": "https://mastodon.social/@Gargron/103270115826048975",
+        "replies_count": 5,
+        "reblogs_count": 6,
+        "favourites_count": 11,
+        "favourited": false,
+        "reblogged": false,
+        "muted": false,
+        "bookmarked": false,
+        "content": "<p>&quot;I lost my inheritance with one wrong digit on my sort code&quot;</p><p><a href=\"https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">theguardian.com/money/2019/dec</span><span class=\"invisible\">/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code</span}</p>",
+        "reblog": null,
+        "application":
+        {
+            "name": "Web",
+            "website": null
+        },
+        "account":
+        {
+            "id": "23634",
+            "username": "noiob",
+            "acct": "noiob@awoo.space",
+            "display_name": "ikea shark fan account",
+            "locked": false,
+            "bot": false,
+            "created_at": "2017-02-08T02:00:53.274Z",
+            "note": "<p>:ms_rainbow_flag:​ :ms_bisexual_flagweb:​ :ms_nonbinary_flag:​ <a href=\"https://awoo.space/tags/awoo\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>awoo</span}.space <a href=\"https://awoo.space/tags/admin\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>admin</span} ~ <a href=\"https://awoo.space/tags/bi\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>bi</span} ~ <a href=\"https://awoo.space/tags/nonbinary\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>nonbinary</span} ~ compsci student ~ likes video <a href=\"https://awoo.space/tags/games\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>games</span} and weird/ old electronics and will post obsessively about both ~ avatar by <span class=\"h-card\"><a href=\"https://weirder.earth/@dzuk\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>dzuk</span}</span></p>",
+            "url": "https://awoo.space/@noiob",
+            "avatar": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+            "avatar_static": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+            "header": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+            "header_static": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+            "followers_count": 547,
+            "following_count": 404,
+            "discoverable": false,
+            "statuses_count": 28468,
+            "last_status_at": "2019-11-17T00:02:23.693Z",
+            "emojis":
+            [
+                {
+                    "shortcode": "ms_rainbow_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/028/691/original/6de008d6281f4f59.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/028/691/static/6de008d6281f4f59.png",
+                    "visible_in_picker": true
+                },
+                {
+                    "shortcode": "ms_bisexual_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/050/744/original/02f94a5fca7eaf78.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/050/744/static/02f94a5fca7eaf78.png",
+                    "visible_in_picker": true
+                },
+                {
+                    "shortcode": "ms_nonbinary_flag",
+                    "url": "https://files.mastodon.social/custom_emojis/images/000/105/099/original/8106088bd4782072.png",
+                    "static_url": "https://files.mastodon.social/custom_emojis/images/000/105/099/static/8106088bd4782072.png",
+                    "visible_in_picker": true
+                }
+            ],
+            "fields":
+            [
+                {
+                    "name": "Pronouns",
+                    "value": "they/them",
+                    "verified_at": null
+                },
+                {
+                    "name": "Alt",
+                    "value": "<span class=\"h-card\"><a href=\"https://cybre.space/@noiob\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>noiob</span}</span>",
+                    "verified_at": null
+                },
+                {
+                    "name": "Bots",
+                    "value": "<span class=\"h-card\"><a href=\"https://botsin.space/@darksouls\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>darksouls</span}</span>, <span class=\"h-card\"><a href=\"https://botsin.space/@nierautomata\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>nierautomata</span}</span>, <span class=\"h-card\"><a href=\"https://mastodon.social/@fedi\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>fedi</span}</span>, code for <span class=\"h-card\"><a href=\"https://botsin.space/@awoobot\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>awoobot</span}</span>",
+                    "verified_at": null
+                },
+                {
+                    "name": "Website",
+                    "value": "<a href=\"http://shork.xyz\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">http://</span><span class=\"\">shork.xyz</span><span class=\"invisible\"></span}",
+                    "verified_at": "2019-11-10T10:31:10.744+00:00"
+                }
+            ]
+        },
+        "media_attachments":
+        [],
+        "mentions":
+        [],
+        "tags":
+        [],
+        "emojis":
+        [],
+        "card":
+        {
+            "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+            "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+            "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+            "type": "link",
+            "author_name": "",
+            "author_url": "",
+            "provider_name": "",
+            "provider_url": "",
+            "html": "",
+            "width": 0,
+            "height": 0,
+            "image": null,
+            "embed_url": ""
+        },
+        "poll": null
+    }
+}

--- a/data/network/src/commonTest/resources/response_instance_invalid.json
+++ b/data/network/src/commonTest/resources/response_instance_invalid.json
@@ -1,0 +1,1 @@
+{"error":"Access denied. Please check your credentials."}

--- a/data/network/src/commonTest/resources/response_instance_valid.json
+++ b/data/network/src/commonTest/resources/response_instance_valid.json
@@ -1,0 +1,63 @@
+{
+  "uri": "mastodon.social",
+  "title": "Mastodon",
+  "description": "Server run by the main developers of the project <img draggable=\"false\" alt=\"🐘\" class=\"emojione\" src=\"https://mastodon.social/emoji/1f418.svg\" /> It is not focused on any particular niche interest - everyone is welcome as long as you follow our code of conduct!",
+  "short_description": "Server run by the main developers of the project <img draggable=\"false\" alt=\"🐘\" class=\"emojione\" src=\"https://mastodon.social/emoji/1f418.svg\" /> It is not focused on any particular niche interest - everyone is welcome as long as you follow our code of conduct!",
+  "email": "staff@mastodon.social",
+  "version": "3.0.1",
+  "languages":
+  [
+    "en"
+  ],
+  "registrations": true,
+  "approval_required": false,
+  "invites_enabled": true,
+  "urls":
+  {
+    "streaming_api": "wss://mastodon.social"
+  },
+  "stats":
+  {
+    "user_count": 415526,
+    "status_count": 17085754,
+    "domain_count": 11834
+  },
+  "user_count": 415526,
+
+  "thumbnail": "https://files.mastodon.social/site_uploads/files/000/000/001/original/vlcsnap-2018-08-27-16h43m11s127.png",
+  "contact_account":
+  {
+    "id": "1",
+    "username": "Gargron",
+    "acct": "Gargron",
+    "display_name": "Eugen",
+    "locked": false,
+    "bot": false,
+    "created_at": "2016-03-16T14:34:26.392Z",
+    "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
+    "url": "https://mastodon.social/@Gargron",
+    "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+    "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+    "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+    "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+    "followers_count": 317112,
+    "following_count": 453,
+    "statuses_count": 60903,
+    "last_status_at": "2019-11-26T21:14:44.522Z",
+    "emojis": [],
+    "discoverable": false,
+    "fields":
+    [
+      {
+        "name": "Patreon",
+        "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
+        "verified_at": null
+      },
+      {
+        "name": "Homepage",
+        "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
+        "verified_at": "2019-07-15T18:29:57.191+00:00"
+      }
+    ]
+  }
+}

--- a/data/network/src/commonTest/resources/response_notification_required.json
+++ b/data/network/src/commonTest/resources/response_notification_required.json
@@ -1,0 +1,158 @@
+{
+    "id": "34975861",
+    "type": "mention",
+    "created_at": "2019-11-23T07:49:02.064Z",
+    "account":
+    {
+        "id": "23634",
+        "username": "noiob",
+        "acct": "noiob@awoo.space",
+        "display_name": "ikea shark fan account",
+        "locked": false,
+        "bot": false,
+        "discoverable": false,
+        "created_at": "2017-02-08T02:00:53.274Z",
+        "note": "<p>:ms_rainbow_flag:​ :ms_bisexual_flagweb:​ :ms_nonbinary_flag:​ <a href=\"https://awoo.space/tags/awoo\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>awoo</span}.space <a href=\"https://awoo.space/tags/admin\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>admin</span} ~ <a href=\"https://awoo.space/tags/bi\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>bi</span} ~ <a href=\"https://awoo.space/tags/nonbinary\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>nonbinary</span} ~ compsci student ~ likes video <a href=\"https://awoo.space/tags/games\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>games</span} and weird/ old electronics and will post obsessively about both ~ avatar by <span class=\"h-card\"><a href=\"https://weirder.earth/@dzuk\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>dzuk</span}</span></p>",
+        "url": "https://awoo.space/@noiob",
+        "avatar": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+        "avatar_static": "https://files.mastodon.social/accounts/avatars/000/023/634/original/6ca8804dc46800ad.png",
+        "header": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+        "header_static": "https://files.mastodon.social/accounts/headers/000/023/634/original/256eb8d7ac40f49a.png",
+        "followers_count": 547,
+        "following_count": 404,
+        "statuses_count": 28468,
+        "last_status_at": "2019-11-17T00:02:23.693Z",
+        "emojis":
+        [
+            {
+                "shortcode": "ms_rainbow_flag",
+                "url": "https://files.mastodon.social/custom_emojis/images/000/028/691/original/6de008d6281f4f59.png",
+                "static_url": "https://files.mastodon.social/custom_emojis/images/000/028/691/static/6de008d6281f4f59.png",
+                "visible_in_picker": true
+            },
+            {
+                "shortcode": "ms_bisexual_flag",
+                "url": "https://files.mastodon.social/custom_emojis/images/000/050/744/original/02f94a5fca7eaf78.png",
+                "static_url": "https://files.mastodon.social/custom_emojis/images/000/050/744/static/02f94a5fca7eaf78.png",
+                "visible_in_picker": true
+            },
+            {
+                "shortcode": "ms_nonbinary_flag",
+                "url": "https://files.mastodon.social/custom_emojis/images/000/105/099/original/8106088bd4782072.png",
+                "static_url": "https://files.mastodon.social/custom_emojis/images/000/105/099/static/8106088bd4782072.png",
+                "visible_in_picker": true
+            }
+        ],
+        "fields":
+        [
+            {
+                "name": "Pronouns",
+                "value": "they/them",
+                "verified_at": null
+            },
+            {
+                "name": "Alt",
+                "value": "<span class=\"h-card\"><a href=\"https://cybre.space/@noiob\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>noiob</span}</span>",
+                "verified_at": null
+            },
+            {
+                "name": "Bots",
+                "value": "<span class=\"h-card\"><a href=\"https://botsin.space/@darksouls\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>darksouls</span}</span>, <span class=\"h-card\"><a href=\"https://botsin.space/@nierautomata\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>nierautomata</span}</span>, <span class=\"h-card\"><a href=\"https://mastodon.social/@fedi\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>fedi</span}</span>, code for <span class=\"h-card\"><a href=\"https://botsin.space/@awoobot\" class=\"u-url mention\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">@<span>awoobot</span}</span>",
+                "verified_at": null
+            },
+            {
+                "name": "Website",
+                "value": "<a href=\"http://shork.xyz\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">http://</span><span class=\"\">shork.xyz</span><span class=\"invisible\"></span}",
+                "verified_at": "2019-11-10T10:31:10.744+00:00"
+            }
+        ]
+    },
+    "status":
+    {
+        "id": "103270115826048975",
+        "created_at": "2019-12-08T03:48:33.901Z",
+        "in_reply_to_id": null,
+        "in_reply_to_account_id": null,
+        "sensitive": false,
+        "spoiler_text": "",
+        "visibility": "public",
+        "language": "en",
+        "uri": "https://mastodon.social/users/Gargron/statuses/103270115826048975",
+        "url": "https://mastodon.social/@Gargron/103270115826048975",
+        "replies_count": 5,
+        "reblogs_count": 6,
+        "favourites_count": 11,
+        "favourited": false,
+        "reblogged": false,
+        "muted": false,
+        "bookmarked": false,
+        "content": "<p>&quot;I lost my inheritance with one wrong digit on my sort code&quot;</p><p><a href=\"https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">theguardian.com/money/2019/dec</span><span class=\"invisible\">/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code</span}</p>",
+        "reblog": null,
+        "application":
+        {
+            "name": "Web",
+            "website": null
+        },
+        "account":
+        {
+            "id": "1",
+            "username": "Gargron",
+            "acct": "Gargron",
+            "display_name": "Eugen",
+            "locked": false,
+            "bot": false,
+            "discoverable": true,
+            "created_at": "2016-03-16T14:34:26.392Z",
+            "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
+            "url": "https://mastodon.social/@Gargron",
+            "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+            "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+            "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+            "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+            "followers_count": 322930,
+            "following_count": 459,
+            "statuses_count": 61323,
+            "last_status_at": "2019-12-10T08:14:44.811Z",
+            "emojis":
+            [],
+            "fields":
+            [
+                {
+                    "name": "Patreon",
+                    "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
+                    "verified_at": null
+                },
+                {
+                    "name": "Homepage",
+                    "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
+                    "verified_at": "2019-07-15T18:29:57.191+00:00"
+                }
+            ]
+        },
+        "media_attachments":
+        [],
+        "mentions":
+        [],
+        "tags":
+        [],
+        "emojis":
+        [],
+        "card":
+        {
+            "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+            "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+            "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+            "type": "link",
+            "author_name": "",
+            "author_url": "",
+            "provider_name": "",
+            "provider_url": "",
+            "html": "",
+            "width": 0,
+            "height": 0,
+            "image": null,
+            "embed_url": ""
+        },
+        "poll": null
+    }
+}

--- a/data/network/src/commonTest/resources/response_status_required.json
+++ b/data/network/src/commonTest/resources/response_status_required.json
@@ -1,0 +1,87 @@
+{
+    "id": "103270115826048975",
+    "created_at": "2019-12-08T03:48:33.901Z",
+    "in_reply_to_id": null,
+    "in_reply_to_account_id": null,
+    "sensitive": false,
+    "spoiler_text": "",
+    "visibility": "public",
+    "language": "en",
+    "uri": "https://mastodon.social/users/Gargron/statuses/103270115826048975",
+    "url": "https://mastodon.social/@Gargron/103270115826048975",
+    "replies_count": 5,
+    "reblogs_count": 6,
+    "favourites_count": 11,
+    "favourited": false,
+    "reblogged": false,
+    "muted": false,
+    "bookmarked": false,
+    "content": "<p>&quot;I lost my inheritance with one wrong digit on my sort code&quot;</p><p><a href=\"https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"ellipsis\">theguardian.com/money/2019/dec</span><span class=\"invisible\">/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code</span}</p>",
+    "reblog": null,
+    "application":
+    {
+        "name": "Web",
+        "website": null
+    },
+    "account":
+    {
+        "id": "1",
+        "username": "Gargron",
+        "acct": "Gargron",
+        "display_name": "Eugen",
+        "locked": false,
+        "bot": false,
+        "discoverable": true,
+        "created_at": "2016-03-16T14:34:26.392Z",
+        "note": "<p>Developer of Mastodon and administrator of mastodon.social. I post service announcements, development updates, and personal stuff.</p>",
+        "url": "https://mastodon.social/@Gargron",
+        "avatar": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+        "avatar_static": "https://files.mastodon.social/accounts/avatars/000/000/001/original/d96d39a0abb45b92.jpg",
+        "header": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+        "header_static": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png",
+        "followers_count": 322930,
+        "following_count": 459,
+        "statuses_count": 61323,
+        "last_status_at": "2019-12-10T08:14:44.811Z",
+        "emojis":
+        [],
+        "fields":
+        [
+            {
+                "name": "Patreon",
+                "value": "<a href=\"https://www.patreon.com/mastodon\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://www.</span><span class=\"\">patreon.com/mastodon</span><span class=\"invisible\"></span}",
+                "verified_at": null
+            },
+            {
+                "name": "Homepage",
+                "value": "<a href=\"https://zeonfederated.com\" rel=\"me nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">zeonfederated.com</span><span class=\"invisible\"></span}",
+                "verified_at": "2019-07-15T18:29:57.191+00:00"
+            }
+        ]
+    },
+    "media_attachments":
+    [],
+    "mentions":
+    [],
+    "tags":
+    [],
+    "emojis":
+    [],
+    "card":
+    {
+        "url": "https://www.theguardian.com/money/2019/dec/07/i-lost-my-193000-inheritance-with-one-wrong-digit-on-my-sort-code",
+        "title": "‘I lost my £193,000 inheritance – with one wrong digit on my sort code’",
+        "description": "When Peter Teich’s money went to another Barclays customer, the bank offered £25 as a token gesture",
+        "type": "link",
+        "author_name": "",
+        "author_url": "",
+        "provider_name": "",
+        "provider_url": "",
+        "html": "",
+        "width": 0,
+        "height": 0,
+        "image": null,
+        "embed_url": ""
+    },
+    "poll": null
+}


### PR DESCRIPTION
## What does this PR do?

Add the implementation and tests for all missing entities of the mastodon api

# Checklist

- [x] Tests have been added / adjusted to keep this feature alive from future changes
- [ ] I've updated the [documentation](~not there yet~) (if applicable)

## How can this PR been tested?


## Tasks Remaining: (List of tasks remaining to be implemented)


## Screenshots (if applicable):

