### PR TITLE
Fix Gradle Daemon on Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.configureondemand=true
 org.gradle.console=rich
 
 # Specifies the JVM arguments used for the daemon process.
-org.gradle.jvmargs=-Xmx7168m -XX:MaxPermSize=256m -XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Xmx7168m -XX:MaxMetaspaceSize=2g
 
 # Gradle will fork up to org.gradle.workers.max JVMs to execute projects in parallel.
 org.gradle.parallel=true


### PR DESCRIPTION
## 📑 What does this PR do?
Gradle daemon fails to start on Java 17 due to unrecognised option `XX:MaxPermSize`. It is safe to remove it since it already ignored since Java 1.8.

# ✅ Checklist

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation <-- BTW I would remove this, to have all the checks filled on every PR.
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## 🧪 How can this PR been tested?
Compile project using JDK17.

## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

- What is remaining to be implemented in this PR? Mention a list of them


## 🖼️ Screenshots (if applicable):
