### PR TITLE
Add ResourceLoader & make tests runnable for Mac

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("social.androiddev.gradle.workarounds")
+}
+
 buildscript {
 
     extra["targetSDKVersion"] = 33

--- a/data/network/build.gradle.kts
+++ b/data/network/build.gradle.kts
@@ -1,7 +1,10 @@
+import social.androiddev.gradle.overrideAppleDevices
+
 plugins {
     id("kotlin-multiplatform")
     id("com.android.library")
     kotlin("plugin.serialization")
+    alias(libs.plugins.test.resources)
 }
 
 val targetSDKVersion: Int by rootProject.extra
@@ -36,6 +39,7 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    overrideAppleDevices()
 
     sourceSets {
         // shared
@@ -105,6 +109,8 @@ kotlin {
                 implementation(libs.io.ktor.client.mock)
                 implementation(libs.org.jetbrains.kotlin.test.common)
                 implementation(libs.org.jetbrains.kotlin.test.annotations.common)
+                implementation(libs.org.jetbrains.kotlinx.coroutines.test)
+                implementation(libs.com.goncalossilva.test.resources)
             }
         }
     }

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/MastodonApiTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/MastodonApiTests.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package social.androiddev.common.network
 
+import com.goncalossilva.resources.Resource
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -10,22 +13,17 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
-import kotlin.test.Ignore
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlin.test.Test
+import kotlin.test.*
 
 class MastodonApiTests {
-    // TODO: fix loading json from resources
-    // @Test
-    fun `Instance request should fail with invalid response`() = runBlocking {
+    @Test
+    @Ignore // this is broken
+    fun `Instance request should fail with invalid response`() = runTest {
         // given
-        // val content: String = javaClass.classLoader.getResource("response_instance_invalid.json").readText()
-        val content: String = ""
+        val content: String = Resource("src/commonTest/resources/response_instance_invalid.json").readText()
         val mastodonApi = MastodonApiImpl(
             httpClient = createMockClient(
                 statusCode = HttpStatusCode.Unauthorized, content = ByteReadChannel(text = content)
@@ -40,12 +38,11 @@ class MastodonApiTests {
         assertNull(actual = result.getOrNull()?.uri)
     }
 
-    // TODO: fix loading json from resources
-    //@Test
-    fun `Instance request should succeed with required field response`() = runBlocking {
+    @Test
+    @Ignore // this is broken
+    fun `Instance request should succeed with required field response`() = runTest {
         // given
-        // val content: String = javaClass.classLoader.getResource("response_instance_valid.json").readText()
-        val content: String = ""
+        val content = Resource("src/commonTest/resources/response_instance_valid.json").readText()
 
         val mastodonApi = MastodonApiImpl(
             httpClient = createMockClient(

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AccountTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AccountTests.kt
@@ -1,20 +1,16 @@
 package social.androiddev.common.network.model
 
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import com.goncalossilva.resources.Resource
 import kotlin.test.Test
 
 class AccountTests {
-    // TODO: fix loading json from resources
-    @Ignore
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
-        //val json: String = javaClass.classLoader.getResource("response_account_required.json").readText()
-        val json: String = ""
+        val json: String = Resource("src/commonTest/resources/response_account_required.json").readText()
 
         // when
         val account = Json.decodeFromString<Account>(json)

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ActivityTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ActivityTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 
 class ActivityTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AnnouncementReactionTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AnnouncementReactionTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 
 class AnnouncementReactionTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         [

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AnnouncementTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AnnouncementTests.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNotNull
 
 class AnnouncementTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ApplicationTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ApplicationTests.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertNull
 
 class ApplicationTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AttachmentTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/AttachmentTests.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.Json
 
 class AttachmentTests {
     @Test
-    fun `deserialize image example should succeed`() = runBlocking {
+    fun `deserialize image example should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ContextTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ContextTests.kt
@@ -5,17 +5,15 @@ import kotlin.test.Ignore
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import com.goncalossilva.resources.Resource
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 class ContextTests {
-    // TODO: fix loading json from resources
-    @Ignore
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
-        // val json: String = javaClass.classLoader.getResource("response_context_required.json").readText()
-        val json: String = ""
+        val json: String = Resource("src/commonTest/resources/response_context_required.json").readText()
 
         // when
         val context = Json.decodeFromString<Context>(json)

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ConversationTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ConversationTests.kt
@@ -1,21 +1,17 @@
 package social.androiddev.common.network.model
 
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import com.goncalossilva.resources.Resource
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 class ConversationTests {
-    // TODO: fix loading json from resources
-    @Ignore
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
-        // val json: String = javaClass.classLoader.getResource("response_conversation_required.json").readText()
-        val json: String = ""
+        val json = Resource("src/commonTest/resources/response_conversation_required.json").readText()
 
         // when
         val conversation = Json.decodeFromString<Conversation>(json)

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/EmojiTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/EmojiTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class EmojiTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ErrorTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/ErrorTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class ErrorTests {
     @Test
-    fun `deserialize video card should succeed`() = runBlocking {
+    fun `deserialize video card should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FeatureTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FeatureTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class FeatureTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FilterTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/FilterTests.kt
@@ -2,13 +2,12 @@ package social.androiddev.common.network.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class FilterTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/HistoryTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/HistoryTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class HistoryTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/IdentityProofTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/IdentityProofTests.kt
@@ -2,13 +2,12 @@ package social.androiddev.common.network.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class IdentityProofTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MarkerTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MarkerTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 
 class MarkerTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MentionTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/MentionTests.kt
@@ -3,13 +3,12 @@ package social.androiddev.common.network.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class MentionTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         [

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/NotificationTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/NotificationTests.kt
@@ -1,21 +1,17 @@
 package social.androiddev.common.network.model
 
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import com.goncalossilva.resources.Resource
 
 class NotificationTests {
-    // TODO: fix loading json from resources
-    @Ignore
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
-        // val json: String = javaClass.classLoader.getResource("response_notification_required.json").readText()
-        val json: String = ""
+        val json: String = Resource("src/commonTest/resources/response_notification_required.json").readText()
 
         // when
         val notification = Json.decodeFromString<Notification>(json)

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PollTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PollTests.kt
@@ -3,13 +3,12 @@ package social.androiddev.common.network.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class PollTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PreferencesTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PreferencesTests.kt
@@ -3,13 +3,12 @@ package social.androiddev.common.network.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class PreferencesTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PushSubscriptionTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/PushSubscriptionTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class PushSubscriptionTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/StatusTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/StatusTests.kt
@@ -6,16 +6,14 @@ import kotlin.test.assertNotNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import com.goncalossilva.resources.Resource
 import kotlin.test.Test
 
 class StatusTests {
-    // TODO: fix loading json from resources
-    @Ignore
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
-        // val json: String = javaClass.classLoader.getResource("response_status_required.json").readText()
-        val json: String = ""
+        val json: String = Resource("src/commonTest/resources/response_status_required.json").readText()
 
         // when
         val status = Json.decodeFromString<Status>(json)

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/TagTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/TagTests.kt
@@ -2,13 +2,12 @@ package social.androiddev.common.network.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 class TagTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/UserListTests.kt
+++ b/data/network/src/commonTest/kotlin/social/androiddev/common/network/model/UserListTests.kt
@@ -1,14 +1,13 @@
 package social.androiddev.common.network.model
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 
 class UserListTests {
     @Test
-    fun `deserialize required fields should succeed`() = runBlocking {
+    fun `deserialize required fields should succeed`() {
         // given
         val json = """
         {

--- a/data/persistence/build.gradle.kts
+++ b/data/persistence/build.gradle.kts
@@ -1,3 +1,5 @@
+import social.androiddev.gradle.overrideAppleDevices
+
 plugins {
     id("kotlin-multiplatform")
     id("com.android.library")
@@ -36,6 +38,7 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    overrideAppleDevices()
 
     sourceSets {
         // shared

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,13 @@ com-squareup-sqldelight = "1.5.3"
 io-ktor = "2.1.3"
 com-google-truth = "1.1.3"
 org-jetbrains-kotlinx = "1.4.1"
+org-jetbrains-kotlinx-coroutines = "1.6.4"
 androidx-core = "1.3.1"
 androidx-appcompat = "1.5.1"
 androidx-activity = "1.6.1"
 androidx-compose-foundation = "1.2.1"
 com-arkivanov-decompose = "1.0.0-alpha-05"
+com-goncalossilva-test-resources = "0.2.4"
 
 
 [libraries]
@@ -35,6 +37,8 @@ io-ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotl
 
 org-jetbrains-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "org-jetbrains-kotlinx" }
 
+org-jetbrains-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "org-jetbrains-kotlinx-coroutines"}
+
 org-jetbrains-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "org-jetbrains-kotlin" }
 org-jetbrains-kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "org-jetbrains-kotlin" }
 org-jetbrains-kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "org-jetbrains-kotlin" }
@@ -51,4 +55,7 @@ androidx-compose-foundation = { module = "androidx.compose.foundation:foundation
 com-arkivanov-decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "com-arkivanov-decompose" }
 com-arkivanov-decompose-extensions-compose-jetbrains = { module = "com.arkivanov.decompose:extensions-compose-jetbrains", version.ref = "com-arkivanov-decompose" }
 
+com-goncalossilva-test-resources = { module = "com.goncalossilva:resources", version.ref = "com-goncalossilva-test-resources" }
+
 [plugins]
+test-resources = { id = "com.goncalossilva.resources", version.ref = "com-goncalossilva-test-resources" }

--- a/gradleWorkarounds/build.gradle.kts
+++ b/gradleWorkarounds/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    `kotlin-dsl`
+    java
+}
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.org.jetbrains.kotlin.gradle.plugin)
+}
+
+gradlePlugin {
+    plugins.register("social.androiddev.gradle.workarounds") {
+        id = "social.androiddev.gradle.workarounds"
+        implementationClass = "social.androiddev.gradle.Workarounds"
+    }
+}

--- a/gradleWorkarounds/settings.gradle.kts
+++ b/gradleWorkarounds/settings.gradle.kts
@@ -1,0 +1,9 @@
+rootProject.name = "gradleWorkarounds"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradleWorkarounds/src/main/kotlin/social/androiddev/gradle/AppleDevicesOverride.kt
+++ b/gradleWorkarounds/src/main/kotlin/social/androiddev/gradle/AppleDevicesOverride.kt
@@ -1,0 +1,22 @@
+package social.androiddev.gradle
+
+import org.gradle.kotlin.dsl.get
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
+
+// see https://youtrack.jetbrains.com/issue/KT-45416/Do-not-use-iPhone-8-simulator-for-Gradle-tests
+fun KotlinMultiplatformExtension.overrideAppleDevices() {
+    val appleTargets = targets.withType(KotlinNativeTargetWithSimulatorTests::class.java)
+
+    appleTargets.forEach { target ->
+        when {
+            target.name.startsWith("ios") -> {
+                target.testRuns["test"].deviceId = "iPhone 14"
+            }
+            target.name.startsWith("watchos") -> {
+                target.testRuns["test"].deviceId = "Apple Watch Series 7 (45mm)"
+            }
+            else -> { /* do nothing */ }
+        }
+    }
+}

--- a/gradleWorkarounds/src/main/kotlin/social/androiddev/gradle/Workarounds.kt
+++ b/gradleWorkarounds/src/main/kotlin/social/androiddev/gradle/Workarounds.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Matthias Geisler (bitPogo) / All rights reserved.
+ *
+ * Use of this source code is governed by Apache License, Version 2.0
+ */
+package social.androiddev.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class Workarounds : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        // nothing to do
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,8 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 rootProject.name="MastodonCompose"
 
+includeBuild("gradleWorkarounds")
+
 include(":app-android")
 include(":app-desktop")
 //include(":app-iOS")


### PR DESCRIPTION
## 📑 What does this PR do?

<!--- Please describe the changes in detail -->
This adds an ResourceLoader aside with a Composite build for Gradle Workarounds (to make build on Mac).
Currently the Workarounds are related to:
- [removed devices](https://youtrack.jetbrains.com/issue/KT-45416/Do-not-use-iPhone-8-simulator-for-Gradle-tests)

# ✅ Checklist

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## 🧪 How can this PR been tested?

## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

- What is remaining to be implemented in this PR? Mention a list of them


## 🖼️ Screenshots (if applicable):
