### PR TITLE
Fix CI status badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mastodon compose client
 [![CC-BY license](https://img.shields.io/badge/License-CC--BY-blue.svg)](https://creativecommons.org/licenses/by-nd/4.0)
-![CI](https://github.com/thebino/MastodonCompose/workflows/CI/badge.svg)
+![CI](https://github.com/AndroidDev-social/MastodonCompose/actions/workflows/continuous-delivery-pipeline.yml/badge.svg)
 
 A multiplatform Mastodon client written in [Kotlin](kotlinlang.org) for the amazing [androiddev.social](https://androiddev.social) community and everyone else who enjoys #Fediverse
 


### PR DESCRIPTION
## 📑 What does this PR do?

Small fix on the `README.md` file to show the correct CI status badge from GitHub Actions, as per documentation: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

# ✅ Checklist

- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

## 🧪 How can this PR be tested?

Verify that the rendered README on GitHub shows the proper status.

## 🖼️ Screenshots (if applicable):

<img width="419" alt="image" src="https://user-images.githubusercontent.com/701471/201478033-5289b77a-5a3d-48a7-a7fc-e53fe2836bd3.png">

