### PR TITLE
Add MastodonTextField component

### DIFF
--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
@@ -1,3 +1,12 @@
+/*
+ * This file is part of MastodonX.
+ *
+ * MastodonX is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * MastodonX is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with MastodonX. If not, see <https://www.gnu.org/licenses/>.
+ */
 package social.androiddev.common.composables.text
 
 //import androidx.compose.desktop.ui.tooling.preview.Preview

--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
@@ -291,7 +291,7 @@ private class DefaultTextFieldColors(
 
 private const val AnimationDuration = 150
 
-//@androidx.compose.desktop.ui.tooling.preview.Preview
+// @androidx.compose.desktop.ui.tooling.preview.Preview
 @Composable
 fun PreviewTextField() {
     MastodonTheme {

--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
@@ -9,7 +9,6 @@
  */
 package social.androiddev.common.composables.text
 
-//import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.interaction.InteractionSource
@@ -42,12 +41,12 @@ import social.androiddev.common.theme.MastodonTheme
 @Composable
 fun MastodonTextField(
     value: String,
+    onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     isError: Boolean = false,
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
-    onValueChange: (String) -> Unit,
     label: @Composable (() -> Unit)? = null,
     placeholder: @Composable (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -292,7 +291,7 @@ private class DefaultTextFieldColors(
 
 private const val AnimationDuration = 150
 
-//@Preview
+@androidx.compose.desktop.ui.tooling.preview.Preview
 @Composable
 fun PreviewTextField() {
     MastodonTheme {

--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
@@ -1,0 +1,301 @@
+package social.androiddev.common.composables.text
+
+//import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import social.androiddev.common.theme.MastodonTheme
+
+@Composable
+fun MastodonTextField(
+    value: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isError: Boolean = false,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    onValueChange: (String) -> Unit,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    colors: TextFieldColors = textFieldColors(),
+) {
+    TextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = false,
+        textStyle = LocalTextStyle.current,
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        isError = isError,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        shape = MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+        colors = colors,
+    )
+}
+
+/**
+ * Creates a [TextFieldColors] that represents the default input text, background and content
+ * (including label, placeholder, leading and trailing icons) colors used in a [TextField].
+ */
+@Composable
+private fun textFieldColors(
+    textColor: Color = LocalContentColor.current.copy(LocalContentAlpha.current),
+    disabledTextColor: Color = textColor.copy(ContentAlpha.disabled),
+    backgroundColor: Color = MaterialTheme.colors.onSurface.copy(alpha = TextFieldDefaults.BackgroundOpacity),
+    cursorColor: Color = MaterialTheme.colors.primary,
+    errorCursorColor: Color = MaterialTheme.colors.error,
+    focusedIndicatorColor: Color =
+        MaterialTheme.colors.primary.copy(alpha = ContentAlpha.high),
+    unfocusedIndicatorColor: Color =
+        MaterialTheme.colors.onSurface.copy(alpha = TextFieldDefaults.UnfocusedIndicatorLineOpacity),
+    disabledIndicatorColor: Color = unfocusedIndicatorColor.copy(alpha = ContentAlpha.disabled),
+    errorIndicatorColor: Color = MaterialTheme.colors.error,
+    leadingIconColor: Color =
+        MaterialTheme.colors.onSurface.copy(alpha = TextFieldDefaults.IconOpacity),
+    disabledLeadingIconColor: Color = leadingIconColor.copy(alpha = ContentAlpha.disabled),
+    errorLeadingIconColor: Color = leadingIconColor,
+    trailingIconColor: Color =
+        MaterialTheme.colors.onSurface.copy(alpha = TextFieldDefaults.IconOpacity),
+    disabledTrailingIconColor: Color = trailingIconColor.copy(alpha = ContentAlpha.disabled),
+    errorTrailingIconColor: Color = MaterialTheme.colors.error,
+    focusedLabelColor: Color = MaterialTheme.colors.primary.copy(alpha = ContentAlpha.high),
+    unfocusedLabelColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium),
+    disabledLabelColor: Color = unfocusedLabelColor.copy(ContentAlpha.disabled),
+    errorLabelColor: Color = MaterialTheme.colors.error,
+    placeholderColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium),
+    disabledPlaceholderColor: Color = placeholderColor.copy(ContentAlpha.disabled)
+): TextFieldColors = DefaultTextFieldColors(
+    textColor = textColor,
+    disabledTextColor = disabledTextColor,
+    cursorColor = cursorColor,
+    errorCursorColor = errorCursorColor,
+    focusedIndicatorColor = focusedIndicatorColor,
+    unfocusedIndicatorColor = unfocusedIndicatorColor,
+    errorIndicatorColor = errorIndicatorColor,
+    disabledIndicatorColor = disabledIndicatorColor,
+    leadingIconColor = leadingIconColor,
+    disabledLeadingIconColor = disabledLeadingIconColor,
+    errorLeadingIconColor = errorLeadingIconColor,
+    trailingIconColor = trailingIconColor,
+    disabledTrailingIconColor = disabledTrailingIconColor,
+    errorTrailingIconColor = errorTrailingIconColor,
+    backgroundColor = backgroundColor,
+    focusedLabelColor = focusedLabelColor,
+    unfocusedLabelColor = unfocusedLabelColor,
+    disabledLabelColor = disabledLabelColor,
+    errorLabelColor = errorLabelColor,
+    placeholderColor = placeholderColor,
+    disabledPlaceholderColor = disabledPlaceholderColor
+)
+
+@Immutable
+private class DefaultTextFieldColors(
+    private val textColor: Color,
+    private val disabledTextColor: Color,
+    private val cursorColor: Color,
+    private val errorCursorColor: Color,
+    private val focusedIndicatorColor: Color,
+    private val unfocusedIndicatorColor: Color,
+    private val errorIndicatorColor: Color,
+    private val disabledIndicatorColor: Color,
+    private val leadingIconColor: Color,
+    private val disabledLeadingIconColor: Color,
+    private val errorLeadingIconColor: Color,
+    private val trailingIconColor: Color,
+    private val disabledTrailingIconColor: Color,
+    private val errorTrailingIconColor: Color,
+    private val backgroundColor: Color,
+    private val focusedLabelColor: Color,
+    private val unfocusedLabelColor: Color,
+    private val disabledLabelColor: Color,
+    private val errorLabelColor: Color,
+    private val placeholderColor: Color,
+    private val disabledPlaceholderColor: Color
+) : TextFieldColors {
+
+    @Composable
+    override fun leadingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
+        return rememberUpdatedState(
+            when {
+                !enabled -> disabledLeadingIconColor
+                isError -> errorLeadingIconColor
+                else -> leadingIconColor
+            }
+        )
+    }
+
+    @Composable
+    override fun trailingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
+        return rememberUpdatedState(
+            when {
+                !enabled -> disabledTrailingIconColor
+                isError -> errorTrailingIconColor
+                else -> trailingIconColor
+            }
+        )
+    }
+
+    @Composable
+    override fun indicatorColor(
+        enabled: Boolean,
+        isError: Boolean,
+        interactionSource: InteractionSource
+    ): State<Color> {
+        val focused by interactionSource.collectIsFocusedAsState()
+
+        val targetValue = when {
+            !enabled -> disabledIndicatorColor
+            isError -> errorIndicatorColor
+            focused -> focusedIndicatorColor
+            else -> unfocusedIndicatorColor
+        }
+        return if (enabled) {
+            animateColorAsState(targetValue, tween(durationMillis = AnimationDuration))
+        } else {
+            rememberUpdatedState(targetValue)
+        }
+    }
+
+    @Composable
+    override fun backgroundColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(backgroundColor)
+    }
+
+    @Composable
+    override fun placeholderColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) placeholderColor else disabledPlaceholderColor)
+    }
+
+    @Composable
+    override fun labelColor(
+        enabled: Boolean,
+        error: Boolean,
+        interactionSource: InteractionSource
+    ): State<Color> {
+        val focused by interactionSource.collectIsFocusedAsState()
+
+        val targetValue = when {
+            !enabled -> disabledLabelColor
+            error -> errorLabelColor
+            focused -> focusedLabelColor
+            else -> unfocusedLabelColor
+        }
+        return rememberUpdatedState(targetValue)
+    }
+
+    @Composable
+    override fun textColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) textColor else disabledTextColor)
+    }
+
+    @Composable
+    override fun cursorColor(isError: Boolean): State<Color> {
+        return rememberUpdatedState(if (isError) errorCursorColor else cursorColor)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as DefaultTextFieldColors
+
+        if (textColor != other.textColor) return false
+        if (disabledTextColor != other.disabledTextColor) return false
+        if (cursorColor != other.cursorColor) return false
+        if (errorCursorColor != other.errorCursorColor) return false
+        if (focusedIndicatorColor != other.focusedIndicatorColor) return false
+        if (unfocusedIndicatorColor != other.unfocusedIndicatorColor) return false
+        if (errorIndicatorColor != other.errorIndicatorColor) return false
+        if (disabledIndicatorColor != other.disabledIndicatorColor) return false
+        if (leadingIconColor != other.leadingIconColor) return false
+        if (disabledLeadingIconColor != other.disabledLeadingIconColor) return false
+        if (errorLeadingIconColor != other.errorLeadingIconColor) return false
+        if (trailingIconColor != other.trailingIconColor) return false
+        if (disabledTrailingIconColor != other.disabledTrailingIconColor) return false
+        if (errorTrailingIconColor != other.errorTrailingIconColor) return false
+        if (backgroundColor != other.backgroundColor) return false
+        if (focusedLabelColor != other.focusedLabelColor) return false
+        if (unfocusedLabelColor != other.unfocusedLabelColor) return false
+        if (disabledLabelColor != other.disabledLabelColor) return false
+        if (errorLabelColor != other.errorLabelColor) return false
+        if (placeholderColor != other.placeholderColor) return false
+        if (disabledPlaceholderColor != other.disabledPlaceholderColor) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = textColor.hashCode()
+        result = 31 * result + disabledTextColor.hashCode()
+        result = 31 * result + cursorColor.hashCode()
+        result = 31 * result + errorCursorColor.hashCode()
+        result = 31 * result + focusedIndicatorColor.hashCode()
+        result = 31 * result + unfocusedIndicatorColor.hashCode()
+        result = 31 * result + errorIndicatorColor.hashCode()
+        result = 31 * result + disabledIndicatorColor.hashCode()
+        result = 31 * result + leadingIconColor.hashCode()
+        result = 31 * result + disabledLeadingIconColor.hashCode()
+        result = 31 * result + errorLeadingIconColor.hashCode()
+        result = 31 * result + trailingIconColor.hashCode()
+        result = 31 * result + disabledTrailingIconColor.hashCode()
+        result = 31 * result + errorTrailingIconColor.hashCode()
+        result = 31 * result + backgroundColor.hashCode()
+        result = 31 * result + focusedLabelColor.hashCode()
+        result = 31 * result + unfocusedLabelColor.hashCode()
+        result = 31 * result + disabledLabelColor.hashCode()
+        result = 31 * result + errorLabelColor.hashCode()
+        result = 31 * result + placeholderColor.hashCode()
+        result = 31 * result + disabledPlaceholderColor.hashCode()
+        return result
+    }
+}
+
+private const val AnimationDuration = 150
+
+//@Preview
+@Composable
+fun PreviewTextField() {
+    MastodonTheme {
+        Surface {
+            var text by remember { mutableStateOf("Hello World") }
+            MastodonTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+            )
+        }
+    }
+}

--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/composables/text/MastodonTextField.kt
@@ -291,7 +291,7 @@ private class DefaultTextFieldColors(
 
 private const val AnimationDuration = 150
 
-@androidx.compose.desktop.ui.tooling.preview.Preview
+//@androidx.compose.desktop.ui.tooling.preview.Preview
 @Composable
 fun PreviewTextField() {
     MastodonTheme {


### PR DESCRIPTION
## 📑 What does this PR do?
- Adds wrapper around TextField composable for custom theming. This will be used in login/sign up screens
<!--- Please describe the changes in detail -->

# ✅ Checklist

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## 🧪 How can this PR been tested?


## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

- What is remaining to be implemented in this PR? Mention a list of them


## 🖼️ Screenshots (if applicable):
