### PR TITLE
Avoid crash when loading async image

### DIFF
--- a/ui/common/src/commonMain/kotlin/social/androiddev/common/utils/AsyncImage.kt
+++ b/ui/common/src/commonMain/kotlin/social/androiddev/common/utils/AsyncImage.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.IOException
+import social.androiddev.common.network.util.runCatchingIgnoreCancelled
 
 /**
  * Use this helper until we switch to a image loading library which supports multiplatform
@@ -36,12 +36,15 @@ fun <T> AsyncImage(
 ) {
     val image: T? by produceState<T?>(null) {
         value = withContext(Dispatchers.IO) {
-            try {
+            runCatchingIgnoreCancelled {
                 load()
-            } catch (e: IOException) {
-                e.printStackTrace()
-                null
-            }
+            }.fold(
+                onSuccess = { it },
+                onFailure = { t ->
+                    t.printStackTrace()
+                    null
+                }
+            )
         }
     }
 


### PR DESCRIPTION
## 📑 What does this PR do?

<!--- Please describe the changes in detail -->
Catch all exceptions throw when trying to load an image async so we avoid the crash and can also support displaying "error" placeholders in the case of any errors.

This fixes the issue reported here: https://github.com/AndroidDev-social/MastodonCompose/issues/83

# ✅ Checklist

- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## 🧪 How can this PR been tested?


## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

- What is remaining to be implemented in this PR? Mention a list of them


## 🖼️ Screenshots (if applicable):
